### PR TITLE
fix: get-admin problem on some Windows systems

### DIFF
--- a/chinese/In-Place_Upgrade_Helper.bat
+++ b/chinese/In-Place_Upgrade_Helper.bat
@@ -4,11 +4,11 @@ Rem Get admin rights
 >nul 2>&1 fsutil dirty query %systemdrive% && (goto gotAdmin) || (goto UACPrompt)
 :UACPrompt
 if exist "%SYSTEMROOT%\System32\Cscript.exe" (
-    echo Set UAC = CreateObject^("Shell.Application"^) : UAC.ShellExecute "%~s0", "", "", "runas", 1 > "%temp%\getadmin.vbs" 
-    "%temp%\getadmin.vbs"
+    echo Set UAC = CreateObject^("Shell.Application"^) : UAC.ShellExecute "%~s0", "", "", "runas", 1 > "%temp%\getadmin.vbs"
+    cscript //nologo "%temp%\getadmin.vbs"
     exit /b
 ) else (
-    powershell -Command "Start-Process -Verb RunAs -FilePath '%0' -ArgumentList 'am_admin'"
+    powershell -Command "Start-Process -Verb RunAs -FilePath '%~s0'"
     exit /b
 )
 :gotAdmin

--- a/english/In-Place_Upgrade_Helper.bat
+++ b/english/In-Place_Upgrade_Helper.bat
@@ -4,11 +4,11 @@ Rem Get admin rights
 >nul 2>&1 fsutil dirty query %systemdrive% && (goto gotAdmin) || (goto UACPrompt)
 :UACPrompt
 if exist "%SYSTEMROOT%\System32\Cscript.exe" (
-    echo Set UAC = CreateObject^("Shell.Application"^) : UAC.ShellExecute "%~s0", "", "", "runas", 1 > "%temp%\getadmin.vbs" 
-    "%temp%\getadmin.vbs"
+    echo Set UAC = CreateObject^("Shell.Application"^) : UAC.ShellExecute "%~s0", "", "", "runas", 1 > "%temp%\getadmin.vbs"
+    cscript //nologo "%temp%\getadmin.vbs"
     exit /b
 ) else (
-    powershell -Command "Start-Process -Verb RunAs -FilePath '%0' -ArgumentList 'am_admin'"
+    powershell -Command "Start-Process -Verb RunAs -FilePath '%~s0'"
     exit /b
 )
 :gotAdmin

--- a/german/In-Place_Upgrade_Helper.bat
+++ b/german/In-Place_Upgrade_Helper.bat
@@ -4,11 +4,11 @@ Rem Admin-Rechte holen
 >nul 2>&1 fsutil dirty query %systemdrive% && (goto gotAdmin) || (goto UACPrompt)
 :UACPrompt
 if exist "%SYSTEMROOT%\System32\Cscript.exe" (
-    echo Set UAC = CreateObject^("Shell.Application"^) : UAC.ShellExecute "%~s0", "", "", "runas", 1 > "%temp%\getadmin.vbs" 
-    "%temp%\getadmin.vbs"
+    echo Set UAC = CreateObject^("Shell.Application"^) : UAC.ShellExecute "%~s0", "", "", "runas", 1 > "%temp%\getadmin.vbs"
+    cscript //nologo "%temp%\getadmin.vbs"
     exit /b
 ) else (
-    powershell -Command "Start-Process -Verb RunAs -FilePath '%0' -ArgumentList 'am_admin'"
+    powershell -Command "Start-Process -Verb RunAs -FilePath '%~s0'"
     exit /b
 )
 :gotAdmin


### PR DESCRIPTION
Fixes a problem with the new get-admin because some Windows systems have “processing errors” in the area:

````
".bat"' -ArgumentList 'am_admin'"" cannot be processed syntactically at this point.
````