### PR TITLE
Fixes errors when running the script.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,21 @@
-* -merge -text
+# Set CRLF for Windows specific script files
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.cmdt text eol=crlf
+*.vbs text eol=crlf
+*.ps1 text eol=crlf
+*.psm1 text eol=crlf
+*.txt text eol=crlf
+*.new text eol=crlf
+*.au3 text eol=crlf
+*.reg text eol=crlf
+*.csv text eol=crlf
+*.cpp text eol=crlf
+*.xsl text eol=crlf
+
+# Set LF for Linux specific script files
+*.sh text eol=lf
+*.bash text eol=lf
+
+# All other files on Auto
+* text=auto


### PR DESCRIPTION
This fixes a bug caused by git (github) changing the line feed from crlf to lf when cloning the repository or possibly downloading the script files, which means that the script may report errors if it does not find gotos.

This commit contains more than the necessary file references. Simply add them here in this pull request or adjust them later so that only the file extensions are required. The last line of the file changed by this commit should remain.

This adjustment of the .gitattributes should take effect immediately. Future clones of the repository will automatically adopt the change to the defined line feed. When downloading the files (but not yet tested in this situation), they could also be offered with the line feed defined there.

#12